### PR TITLE
support devmode & old browsers

### DIFF
--- a/public/modulepreload-support.js
+++ b/public/modulepreload-support.js
@@ -1,0 +1,1 @@
+// empty file to verify modulepreload support

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,27 @@
 const main = async () => {
   let cache;
-  self.addEventListener("activate", async () => {
+
+  const fetchResponse = async (event) => {
+    const req = event.request;
+    // Check cache
+    const cachedResponse = await caches.match(req);
+    if (cachedResponse) return cachedResponse;
+
+    // Check preload response
+    const response = await event.preloadResponse;
+    if (response) return response;
+
+    // Cache and return reponse
+    return fetch(req).then((res) => {
+      if (req.url.includes("q-")) {
+        cache.put(req, res.clone());
+      }
+      return res;
+    })
+  }
+
+  self.addEventListener("activate", async (event) => {
+    event.waitUntil(self.registration.navigationPreload?.enable());
     cache ||= await caches.open("QwikModulePreload");
   });
   self.addEventListener("message", async (message) => {
@@ -11,20 +32,7 @@ const main = async () => {
     }
   });
   self.addEventListener("fetch", async (event) => {
-    const req = event.request;
-    const match = await cache.match(req);
-    if (match) {
-      event.respondWith(match);
-    } else {
-      event.respondWith(
-        fetch(req).then((res) => {
-          if (req.url.includes("q-")) {
-            cache.put(req, res.clone());
-          }
-          return res;
-        })
-      );
-    }
+    event.respondWith(fetchResponse(event));
   });
 };
 main();

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,7 @@ const main = async () => {
   });
   self.addEventListener("message", async (message) => {
     cache ||= await caches.open("QwikModulePreload");
-    if (message.data.type === "cache") {
+    if (message.data.type === "init") {
       const bundles = Array.from(new Set(message.data.value));
       cache.addAll(bundles);
     }

--- a/src/components/ModulePreload.tsx
+++ b/src/components/ModulePreload.tsx
@@ -1,0 +1,53 @@
+import { component$, sync$, useOnWindow } from "@builder.io/qwik";
+import { isDev } from "@builder.io/qwik/build";
+
+export const ModulePreload = component$(() => {
+  useOnWindow(
+    "DOMContentLoaded",
+    sync$(async () => {
+      const base = document.documentElement.getAttribute("q:base") ?? "/";
+      
+      // Initialize SW & cache
+      if ("serviceWorker" in navigator && !document.querySelector('[q\\:render="ssr-dev"]')) {
+        await navigator.serviceWorker.register("/sw.js");
+        await navigator.serviceWorker.ready;
+        const modules = document.querySelectorAll('link[rel="modulepreload"]');
+        const controller = navigator.serviceWorker.controller;
+        const hrefs = Array.from(modules).map(
+          (link) => (link as HTMLLinkElement).href
+        );
+        controller?.postMessage({ type: "init", value: hrefs });
+      }
+
+      const getHref = (bundle: string) => {
+        if (isDev) return bundle;
+        return `${base}${bundle}`.replace(/\/\./g, "");
+      }
+
+      // Listen on prefetch event
+      document.addEventListener("qprefetch", (event) => {
+        const { bundles } = (event as CustomEvent).detail;
+        if (!Array.isArray(bundles)) return;
+        for (const bundle of bundles) {
+          if ((window as any).supportsModulePreload) {
+            const link = document.createElement("link");
+            link.rel = "modulepreload";
+            link.href = getHref(bundle);
+            // TODO: use fetchpriority to priorize some bundles if needed
+            document.body.appendChild(link);
+          } else {
+            // triggers the sw
+            fetch(getHref(bundle));
+          }
+        }
+      });
+    })
+  );
+
+  return <link
+    rel="modulepreload"
+    href="/modulepreload-support.js"
+    fetchPriority="high"
+    onload="window.supportsModulePreload = true"
+  />
+})

--- a/src/components/ModulePreload.tsx
+++ b/src/components/ModulePreload.tsx
@@ -1,14 +1,13 @@
 import { component$, sync$, useOnWindow } from "@builder.io/qwik";
-import { isDev } from "@builder.io/qwik/build";
 
 export const ModulePreload = component$(() => {
   useOnWindow(
     "DOMContentLoaded",
     sync$(async () => {
       const base = document.documentElement.getAttribute("q:base") ?? "/";
-      
+      const isDev = document.documentElement.getAttribute('q:render') === "ssr-dev";
       // Initialize SW & cache
-      if ("serviceWorker" in navigator && !document.querySelector('[q\\:render="ssr-dev"]')) {
+      if ("serviceWorker" in navigator && !isDev) {
         await navigator.serviceWorker.register("/sw.js");
         await navigator.serviceWorker.ready;
         const modules = document.querySelectorAll('link[rel="modulepreload"]');
@@ -44,10 +43,14 @@ export const ModulePreload = component$(() => {
     })
   );
 
+  const support = sync$(() => {
+    (window as any).supportsModulePreload = true;
+  })
+
   return <link
     rel="modulepreload"
     href="/modulepreload-support.js"
     fetchPriority="high"
-    onload="window.supportsModulePreload = true"
+    onLoad$={support}
   />
 })

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -2,8 +2,10 @@ import { component$ } from "@builder.io/qwik";
 import { QwikCityProvider, RouterOutlet } from "@builder.io/qwik-city";
 import { RouterHead } from "./components/router-head/router-head";
 import { isDev } from "@builder.io/qwik/build";
+import { ModulePreload } from "./components/ModulePreload";
 
 import "./global.css";
+
 
 export default component$(() => {
   /**
@@ -24,6 +26,7 @@ export default component$(() => {
           />
         )}
         <RouterHead />
+        <ModulePreload />
       </head>
       <body lang="en">
         <RouterOutlet />

--- a/src/routes/about/index.tsx
+++ b/src/routes/about/index.tsx
@@ -1,0 +1,14 @@
+import { $, component$ } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
+
+export default component$(() => {
+  // This function should have been prefetch when user arrives on the page.
+  const click = $(() => alert('Clicked'));
+  return (
+    <article>
+      <Link href="/">Home</Link>
+      <h1>About</h1>
+      <button onClick$={click}>Trigger action</button>
+    </article>
+  )
+})

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,39 +1,8 @@
-import { sync$, component$, useOnWindow } from "@builder.io/qwik";
-import type { DocumentHead } from "@builder.io/qwik-city";
+import { component$ } from "@builder.io/qwik";
+import { Link, type DocumentHead } from "@builder.io/qwik-city";
 import { Counter } from "~/components/counter/counter";
 
 export default component$(() => {
-  useOnWindow(
-    "DOMContentLoaded",
-    sync$(async () => {
-      if (document.querySelector('[q\\:render="ssr-dev"]')) return;
-      if (!("serviceWorker" in navigator)) return;
-      const base = document.documentElement.getAttribute("q:base") ?? "/";
-      await navigator.serviceWorker.register("sw.js");
-      await navigator.serviceWorker.ready;
-      const modules = document.querySelectorAll('link[rel="modulepreload"]');
-      const controller = navigator.serviceWorker.controller;
-
-      // Initialize cache
-      const hrefs = Array.from(modules).map(
-        (link) => (link as HTMLLinkElement).href
-      );
-      controller?.postMessage({ type: "cache", value: hrefs });
-
-      // Listen on prefetch event
-      document.addEventListener("qprefetch", (event) => {
-        const { bundles } = (event as CustomEvent).detail;
-        console.log(bundles);
-        if (!Array.isArray(bundles)) return;
-        for (const bundle of bundles) {
-          const link = document.createElement("link");
-          link.rel = "modulepreload";
-          link.href = `${base}${bundle}`.replace(/\/\./g, "");
-          document.body.appendChild(link);
-        }
-      });
-    })
-  );
 
   return (
     <>
@@ -43,6 +12,7 @@ export default component$(() => {
         <br />
         Happy coding.
       </div>
+      <Link href="/about">About</Link>
       <Counter />
     </>
   );


### PR DESCRIPTION
- [x] **Devmode**: Support modulepreload but do not start SW
- [x] **Support**: try to load an empty file to see if `modulepreload` is supported
- [x] **Fallback**: If modulepreload is not supported, do a `fetch` instead of adding a `modulepeload` link.

I created a new page to test speculative `prefetch` with `modulepreload` and moved the code into it's own component.

Todo: 
- [ ] Get imports from the bundles from q-manifest or something like that to `prefetch` all modules.
- [ ] `linkInsert` in devmode doesn't work because it prefix all url with `/build`
- [x] I use standard html onload="window.supportsModulePreload = true", which breaks qwik build. Using `onLoad$` & `sync$` wasn't working in devmode.